### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Baraag [![Build Status](https://travis-ci.org/orangain/baraag.png)](https://travis-ci.org/orangain/baraag) [![Latest release](https://pypip.in/v/baraag/badge.png)](https://crate.io/packages/baraag)
+Baraag [![Build Status](https://travis-ci.org/orangain/baraag.png)](https://travis-ci.org/orangain/baraag) [![Latest release](https://img.shields.io/pypi/v/baraag.svg)](https://crate.io/packages/baraag)
 ==========================================================================================================
 
 **WARNING: This project is not maintained anymore. Baraag does not work with the current version of Evernote.app.**


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20baraag))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `baraag`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.